### PR TITLE
fix: add link to mobile site name

### DIFF
--- a/src/_includes/partials/header.njk
+++ b/src/_includes/partials/header.njk
@@ -7,11 +7,10 @@
       <span>Toggle navigation drawer</span>
     </button>
 
-    <span class="mu-d-lg-none mu-ml-02 mu-fw-semi-bold mu-text-default">MDS</span>
-
-    <a href="/" class="[ mcc-navigation-header__button ] mu-d-none mu-d-lg-flex">
-      <span class="mds-site-name-logo mu-d-flex mu-align-items-center">{% include "./logo.njk" %}</span>
-      <span class="mu-fw-semi-bold mu-text-default">Mosaic Design System</span>
+    <a href="/" class="mcc-navigation-header__button">
+      <span class="[ mds-site-name-logo ] [ mu-d-none mu-d-lg-flex mu-align-items-center ]">{% include "./logo.njk" %}</span>
+      <span class="mu-d-none mu-d-lg-flex mu-fw-semi-bold mu-text-default">Mosaic Design System</span>
+      <span class="mu-d-lg-none mu-ml-00 mu-fw-semi-bold mu-text-default">MDS</span>
     </a>
   </nav>
 


### PR DESCRIPTION
This PR adds a link behind the site name on mobile, so users can navigate back to the home page. 